### PR TITLE
Fix an issue with removed annotations being re-added

### DIFF
--- a/OCMapView/OCMapView.m
+++ b/OCMapView/OCMapView.m
@@ -95,12 +95,14 @@
 
 - (void)removeAnnotation:(id < MKAnnotation >)annotation {
     [_allAnnotations removeObject:annotation];
+    [_annotationsToIgnore removeObject:annotation];
     [self doClustering];
 }
 
 - (void)removeAnnotations:(NSArray *)annotations{
     for (id<MKAnnotation> annotation in annotations) {
         [_allAnnotations removeObject:annotation];
+        [_annotationsToIgnore removeObject:annotation];
     }
     [self doClustering];
 }


### PR DESCRIPTION
If you remove an annotation that was excluded from clustering from the map,
it is possible for it to be re-added, because _allAnnotations does not contain it,
but _annotationsToIgnore does. So at the end of doClustering, we add all annotations
that are in _annotationsToIgnore, regardless of whether they are part of the map or not.

This makes sure the invariant that _allAnnotations ⊇ _annotationsToIgnore is true